### PR TITLE
Fix inventory discrepancy report and planner error handling

### DIFF
--- a/src/state.py
+++ b/src/state.py
@@ -38,4 +38,7 @@ class AppState(TypedDict, total=False):
 
     # 専門家エージェント呼び出し
     next_agent: str
-    agent_parameters: Dict[str, Any] 
+    agent_parameters: Dict[str, Any]
+
+    # エラー情報
+    errors: List[str]

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -52,7 +52,6 @@ def build_graph() -> Any:
     sg.add_node("human_validator", ask_human_validation)
     sg.add_node("inventory_matching_agent", inventory_matching_agent_node)
     sg.add_node("receivables_reconciliation_agent", receivables_reconciliation_agent_node)
-    sg.add_node("accounting_reconciliation_agent", receivables_reconciliation_agent_node)
 
     # エントリーポイントをプランナーに設定
     sg.set_entry_point("planner")
@@ -79,7 +78,6 @@ def build_graph() -> Any:
             "human_validator": "human_validator",
             "inventory_matching_agent": "inventory_matching_agent",
             "receivables_reconciliation_agent": "receivables_reconciliation_agent",
-            "accounting_reconciliation_agent": "receivables_reconciliation_agent",
             "__end__": END,
         },
     )
@@ -95,7 +93,6 @@ def build_graph() -> Any:
         "human_validator",
         "inventory_matching_agent",
         "receivables_reconciliation_agent",
-        "accounting_reconciliation_agent",
     ]:
         sg.add_edge(node_name, "planner")
 


### PR DESCRIPTION
## Summary
- stop planner when parameter extraction fails and record error
- generate discrepancy reports from unreconciled data
- support `errors` list in `AppState`
- remove outdated accounting alias from workflow

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6b7ff7048322b7d76a4c52d98a75