### PR TITLE
Implement HR validation via generic workflow

### DIFF
--- a/src/agents/employee_data_validator_agent.py
+++ b/src/agents/employee_data_validator_agent.py
@@ -1,82 +1,53 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 import pathlib
 
 from src.state import AppState
-from src.tools.csv_reader import csv_reader  # type: ignore
-from src.tools.excel_reader import excel_reader  # type: ignore
-from src.tools.csv_writer import csv_writer  # type: ignore
+from src.workflows.generic_matching_workflow import generic_matching_workflow
 from src.agent_framework.specialist_agent import build_specialist_graph
-
-
-# ---------------------------------------------------------------------------
-# 補助関数
-# ---------------------------------------------------------------------------
-
-def _read(path: str) -> List[Dict[str, Any]]:
-    """拡張子で CSV / Excel を自動判定して読み込む"""
-    ext = pathlib.Path(path).suffix.lower()
-    if ext == ".csv":
-        return csv_reader(path)
-    elif ext in {".xlsx", ".xls"}:
-        return excel_reader(path)
-    else:
-        raise ValueError(f"Unsupported file extension: {ext}")
 
 
 # ---------------------------------------------------------------------------
 # ノード定義
 # ---------------------------------------------------------------------------
 
-def _validate_hr(state: AppState) -> AppState:
-    """人事マスタと部門リストの不整合を検出し CSV 出力"""
-    master_file = state.get("input_files", {}).get("deposit")  # type: ignore[assignment]
-    dept_file = state.get("input_files", {}).get("billing")  # type: ignore[assignment]
+def _ensure_files(state: AppState) -> AppState:
+    """入力ファイルを確定して state に保持"""
+    params: Dict[str, Any] = state.get("agent_parameters", {})
+    files = state.get("input_files", {})
 
-    if not master_file or not dept_file:
-        raise RuntimeError("employee_data_validator_agent: 必要な input_files が不足しています。")
+    state["_src_file"] = params.get("source_file") or files.get("deposit")
+    state["_tgt_file"] = params.get("target_file") or files.get("billing")
+    if not state["_src_file"] or not state["_tgt_file"]:
+        raise RuntimeError("employee_data_validator_agent: source/target file missing")
+    return state
 
-    master_rows = _read(master_file)
-    dept_rows = _read(dept_file)
 
-    master_index = {str(r.get("employee_id")): r for r in master_rows}
+def _run_validation(state: AppState) -> AppState:
+    """汎用ワークフローを利用して人事データ検証を実行"""
+    params: Dict[str, Any] = state.get("agent_parameters", {})
+    if "_src_file" not in state or "_tgt_file" not in state:
+        state = _ensure_files(state)
 
-    report_rows: List[Dict[str, Any]] = []
-    for d in dept_rows:
-        emp_id = str(d.get("emp_id"))
-        m = master_index.get(emp_id)
-        if not m:
-            continue
+    validation_rules = params.get("validation_rules") or [
+        {"field": "department_code", "target_field": "dept", "severity": "Warning"},
+        {"field": "title_code", "severity": "Error"},
+    ]
 
-        if m.get("department_code") != d.get("dept"):
-            report_rows.append(
-                {
-                    "employee_id": emp_id,
-                    "field": "department_code",
-                    "master_value": m.get("department_code"),
-                    "list_value": d.get("dept"),
-                    "severity": "Warning",
-                }
-            )
+    results = generic_matching_workflow(
+        source_file=state["_src_file"],
+        target_file=state["_tgt_file"],
+        source_key=params.get("source_key", "employee_id"),
+        target_key=params.get("target_key", "emp_id"),
+        validation_rules=validation_rules,
+        output_dir=str(pathlib.Path(params.get("output_dir", "output")).resolve()),
+        report_filename="inconsistent_hr_data.csv",
+    )
 
-        if m.get("title_code") != d.get("title_code"):
-            report_rows.append(
-                {
-                    "employee_id": emp_id,
-                    "field": "title_code",
-                    "master_value": m.get("title_code"),
-                    "list_value": d.get("title_code"),
-                    "severity": "Error",
-                }
-            )
-
-    output_dir = pathlib.Path("output").resolve()
-    output_dir.mkdir(exist_ok=True)
-    report_path = str(output_dir / "inconsistent_hr_data.csv")
-    csv_writer(report_rows, report_path)
-
-    state.setdefault("final_output_paths", {})["inconsistent_hr_data"] = report_path
+    report_path = results.get("report")
+    if report_path:
+        state.setdefault("final_output_paths", {})["inconsistent_hr_data"] = report_path
     return state
 
 
@@ -85,7 +56,8 @@ def _validate_hr(state: AppState) -> AppState:
 # ---------------------------------------------------------------------------
 
 _NODE_MAP = {
-    "validate_hr_data": _validate_hr,
+    "ensure_files": _ensure_files,
+    "run_validation": _run_validation,
 }
 
 _GRAPH = build_specialist_graph(_NODE_MAP)
@@ -99,4 +71,4 @@ def employee_data_validator_agent(state: AppState) -> AppState:  # noqa: D401
     """人事データ検証エージェント (planner 付き LangGraph 版)"""
     final_state = _GRAPH.invoke(state)
     final_state["plan_next"] = "__end__"
-    return final_state 
+    return final_state

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -5,6 +5,7 @@ from .excel_reader import excel_reader  # noqa: F401
 from .key_based_matcher import key_based_matcher  # noqa: F401
 from .difference_validator import difference_validator  # noqa: F401
 from .numeric_field_validator import numeric_field_validator  # noqa: F401
+from .string_field_validator import string_field_validator  # noqa: F401
 from .csv_writer import csv_writer  # noqa: F401
 from .human_validator import human_validator  # noqa: F401
 from .instruction_parser import parse_instruction_file  # noqa: F401
@@ -16,6 +17,7 @@ __all__ = [
     "key_based_matcher",
     "difference_validator",
     "numeric_field_validator",
+    "string_field_validator",
     "csv_writer",
     "human_validator",
     "parse_instruction_file",

--- a/src/tools/string_field_validator.py
+++ b/src/tools/string_field_validator.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Utility validator for simple string equality."""
+
+def string_field_validator(value1: object, value2: object) -> bool:
+    """Return True if values are identical when cast to string."""
+    return str(value1) == str(value2)

--- a/src/workflows/generic_matching_workflow.py
+++ b/src/workflows/generic_matching_workflow.py
@@ -9,6 +9,7 @@ from ..tools.excel_reader import excel_reader
 from ..tools.key_based_matcher import key_based_matcher
 from ..tools.csv_writer import csv_writer
 from ..tools.numeric_field_validator import numeric_field_validator
+from ..tools.string_field_validator import string_field_validator
 
 
 # --------------------------------------------------------------------------------------
@@ -35,9 +36,11 @@ def generic_matching_workflow(
     target_key: str,
     output_dir: str = "output",
     numeric_field: str = "amount",
-    target_numeric_field: str = None,  # 追加: ターゲット側の数値フィールド名
+    target_numeric_field: str | None = None,
     tolerance_pct: float = 0.0,
-    # Dependency injection hooks -------------------------------------------------
+    validation_rules: List[Dict[str, Any]] | None = None,
+    report_filename: str = "validation_report.csv",
+    # Dependency injection hooks -----------------------------------------------
     source_reader: Callable[[str], List[Dict[str, Any]]] = _default_reader,
     target_reader: Callable[[str], List[Dict[str, Any]]] = _default_reader,
     matcher: Callable[..., Dict[str, Any]] = key_based_matcher,
@@ -54,6 +57,8 @@ def generic_matching_workflow(
         numeric_field: 照合対象の数値フィールド名（source側）。
         target_numeric_field: 照合対象の数値フィールド名（target側）。Noneの場合はnumeric_fieldと同じ。
         tolerance_pct: 許容誤差(%)。
+        validation_rules: 検証ルールのリスト。指定がある場合はそちらを優先。
+        report_filename: validation_rules 利用時の出力ファイル名。
         source_reader: 依存性注入用リーダ関数(デフォルトは拡張子自動判定)。
         target_reader: 依存性注入用リーダ関数。
         matcher: マッチング関数。
@@ -88,46 +93,89 @@ def generic_matching_workflow(
 
     matched_pairs: List[Dict[str, Any]] = match_results.get("matched_pairs", [])
 
-    reconciled: List[Dict[str, Any]] = []
-    unreconciled: List[Dict[str, Any]] = []
+    if validation_rules is None:
+        reconciled: List[Dict[str, Any]] = []
+        unreconciled: List[Dict[str, Any]] = []
 
-    # ------------------------------------------------------------------
-    # 3. 各ペアの数値バリデーション
-    # ------------------------------------------------------------------
+        # --------------------------------------------------------------
+        # 3. 単一数値フィールドのバリデーション
+        # --------------------------------------------------------------
+        for pair in matched_pairs:
+            src = pair["deposit"]  # key_based_matcher の命名を流用
+            tgt = pair["billing"]
+
+            try:
+                v1 = float(src.get(numeric_field, 0))
+                v2 = float(tgt.get(target_numeric_field, 0))
+            except (ValueError, TypeError):
+                pair["validation_error"] = "invalid_numeric"
+                unreconciled.append({**src, **tgt, **pair})
+                continue
+
+            if validator(v1, v2, tolerance_pct):
+                reconciled.append({**src, **tgt})
+            else:
+                diff = v1 - v2
+                unreconciled.append({**src, **tgt, "difference": diff})
+
+        # unmatched データも未突合に追加
+        unreconciled.extend(match_results.get("unmatched_deposit", []))
+        unreconciled.extend(match_results.get("unmatched_billing", []))
+
+        # --------------------------------------------------------------
+        # 4. CSV 出力
+        # --------------------------------------------------------------
+        os.makedirs(output_dir, exist_ok=True)
+        reconciled_path = str(pathlib.Path(output_dir) / "reconciled.csv")
+        unreconciled_path = str(pathlib.Path(output_dir) / "unreconciled.csv")
+
+        csv_writer(reconciled, reconciled_path)
+        csv_writer(unreconciled, unreconciled_path)
+
+        return {
+            "reconciled": reconciled_path,
+            "unreconciled": unreconciled_path,
+        }
+
+    # --------------------------------------------------------------
+    # validation_rules を利用した汎用検証
+    # --------------------------------------------------------------
+    report_rows: List[Dict[str, Any]] = []
     for pair in matched_pairs:
-        src = pair["deposit"]  # key_based_matcher の命名を流用
+        src = pair["deposit"]
         tgt = pair["billing"]
+        key_value = src.get(source_key)
 
-        try:
-            v1 = float(src.get(numeric_field, 0))
-            v2 = float(tgt.get(target_numeric_field, 0))
-        except (ValueError, TypeError):
-            # 数値変換できなければ未突合扱い
-            pair["validation_error"] = "invalid_numeric"
-            unreconciled.append({**src, **tgt, **pair})
-            continue
+        for rule in validation_rules:
+            src_field = rule.get("source_field") or rule.get("field")
+            tgt_field = rule.get("target_field", src_field)
+            severity = rule.get("severity", "Error")
+            v1 = src.get(src_field)
+            v2 = tgt.get(tgt_field)
+            if rule.get("validator") == "numeric":
+                tol = float(rule.get("tolerance_pct", 0.0))
+                try:
+                    n1 = float(v1)
+                    n2 = float(v2)
+                except (ValueError, TypeError):
+                    mismatch = True
+                else:
+                    mismatch = not validator(n1, n2, tol)
+            else:
+                mismatch = not string_field_validator(v1, v2)
 
-        if validator(v1, v2, tolerance_pct):
-            reconciled.append({**src, **tgt})
-        else:
-            diff = v1 - v2
-            unreconciled.append({**src, **tgt, "difference": diff})
+            if mismatch:
+                report_rows.append(
+                    {
+                        source_key: key_value,
+                        "field": src_field,
+                        "master_value": v1,
+                        "list_value": v2,
+                        "severity": severity,
+                    }
+                )
 
-    # unmatched データも未突合に追加
-    unreconciled.extend(match_results.get("unmatched_deposit", []))
-    unreconciled.extend(match_results.get("unmatched_billing", []))
-
-    # ------------------------------------------------------------------
-    # 4. CSV 出力
-    # ------------------------------------------------------------------
     os.makedirs(output_dir, exist_ok=True)
-    reconciled_path = str(pathlib.Path(output_dir) / "reconciled.csv")
-    unreconciled_path = str(pathlib.Path(output_dir) / "unreconciled.csv")
-
-    csv_writer(reconciled, reconciled_path)
-    csv_writer(unreconciled, unreconciled_path)
-
-    return {
-        "reconciled": reconciled_path,
-        "unreconciled": unreconciled_path,
-    }
+    report_path = str(pathlib.Path(output_dir) / report_filename)
+    csv_writer(report_rows, report_path)
+    return {"report": report_path}


### PR DESCRIPTION
## Summary
- extend `generic_matching_workflow` to support multiple validation rules
- add simple `string_field_validator`
- refactor `EmployeeDataValidatorAgent` to reuse the generic workflow
- enhance planner schema to extract complex `validation_rules`

## Testing
- `pytest -q` *(fails: planner couldn't reach OpenAI API)*
- `unset OPENAI_API_KEY; pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfc15c7608322ad6aa13ce5eafd51